### PR TITLE
twitterX icon added

### DIFF
--- a/src/icons/twitterx.tsx
+++ b/src/icons/twitterx.tsx
@@ -20,7 +20,7 @@ interface IconProps extends SVGAttributes<SVGElement> {
     size?: string | number;
 }
 
-const twitterX = forwardRef<SVGSVGElement, IconProps>(({ color = "currentColor", size = 24, ...rest }, ref) => {
+const TwitterX = forwardRef<SVGSVGElement, IconProps>(({ color = "currentColor", size = 24, ...rest }, ref) => {
     return (
         <svg
             ref={ref}
@@ -40,5 +40,5 @@ const twitterX = forwardRef<SVGSVGElement, IconProps>(({ color = "currentColor",
     );
 });
 
-twitterX.displayName = "TwitterX";
-export default twitterX;
+TwitterX.displayName = "TwitterX";
+export default TwitterX;

--- a/src/icons/twitterx.tsx
+++ b/src/icons/twitterx.tsx
@@ -28,14 +28,13 @@ const TwitterX = forwardRef<SVGSVGElement, IconProps>(({ color = "currentColor",
             width={size}
             height={size}
             viewBox="0 0 24 24"
-            fill="none"
-            stroke={color}
+            fill={color}
             strokeWidth="2"
             strokeLinecap="round"
             strokeLinejoin="round"
             {...rest}
         >
-            <path d="M12.6.75h2.454l-5.36 6.142L16 15.25h-4.937l-3.867-5.07-4.425 5.07H.316l5.733-6.57L0 .75h5.063l3.495 4.633L12.601.75Zm-.86 13.028h1.36L4.323 2.145H2.865z"/>
+            <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"></path>
         </svg>
     );
 });

--- a/src/icons/twitterx.tsx
+++ b/src/icons/twitterx.tsx
@@ -1,0 +1,44 @@
+import React, { forwardRef, SVGAttributes } from "react";
+
+/******************************************************************************
+Copyright (c) Varun V.
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+***************************************************************************** */
+
+interface IconProps extends SVGAttributes<SVGElement> {
+    color?: string;
+    size?: string | number;
+}
+
+const twitterX = forwardRef<SVGSVGElement, IconProps>(({ color = "currentColor", size = 24, ...rest }, ref) => {
+    return (
+        <svg
+            ref={ref}
+            xmlns="http://www.w3.org/2000/svg"
+            width={size}
+            height={size}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke={color}
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            {...rest}
+        >
+            <path d="M12.6.75h2.454l-5.36 6.142L16 15.25h-4.937l-3.867-5.07-4.425 5.07H.316l5.733-6.57L0 .75h5.063l3.495 4.633L12.601.75Zm-.86 13.028h1.36L4.323 2.145H2.865z"/>
+        </svg>
+    );
+});
+
+twitterX.displayName = "TwitterX";
+export default twitterX;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -320,6 +320,7 @@ export const Truck: Icon;
 export const Tv: Icon;
 export const Twitch: Icon;
 export const Twitter: Icon;
+export const TwitterX: Icon;
 export const Type: Icon;
 export const TypeScript: Icon;
 export const Umbrella: Icon;

--- a/src/index.ts
+++ b/src/index.ts
@@ -310,6 +310,7 @@ export { default as Truck } from "./icons/truck";
 export { default as Tv } from "./icons/tv";
 export { default as Twitch } from "./icons/twitch";
 export { default as Twitter } from "./icons/twitter";
+export { default as TwitterX } from "./icons/twitterx";
 export { default as Type } from "./icons/type";
 export { default as TypeScript } from "./icons/typescript";
 export { default as Umbrella } from "./icons/umbrella";


### PR DESCRIPTION
The missing twitterX icon is created in twitterX.tsx of the icons folder and the type export in index.d.ts and twitterX export in index.ts is done.